### PR TITLE
Updated qs dependency to fix snyk vulnerabilities report

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "multiparty": "~4.1.2",
     "on-finished": "~2.3.0",
-    "qs": "~4.0.0",
+    "qs": "6.0.4",
     "type-is": "~1.6.4"
   },
   "scripts": {


### PR DESCRIPTION
Running snyk:

```
$ snyk test
✗ High severity vulnerability found on qs@4.0.0
- desc: Prototype Override Protection Bypass
- info: https://snyk.io/vuln/npm:qs:20170213
- from: connect-multiparty@2.0.0 > qs@4.0.0
Upgrade direct dependency qs@4.0.0 to qs@6.0.4
```