### PR TITLE
update dependencies for Node 14+ compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "repository": "expressjs/connect-multiparty",
   "dependencies": {
-    "http-errors": "~1.7.3",
-    "multiparty": "~4.2.1",
+    "http-errors": "~1.8.0",
+    "multiparty": "^4.2.2",
     "on-finished": "~2.3.0",
-    "qs": "~6.7.0",
+    "qs": "~6.10.0",
     "type-is": "~1.6.18"
   },
   "engines": {
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "connect": "3.7.0",
-    "deep-equal": "1.0.1",
-    "eslint": "6.2.1",
-    "mocha": "6.2.1",
-    "nyc": "14.1.1",
-    "safe-buffer": "5.2.0",
-    "supertest": "4.0.2"
+    "deep-equal": "2.0.5",
+    "eslint": "7.22.0",
+    "mocha": "8.3.2",
+    "nyc": "15.1.0",
+    "safe-buffer": "5.2.1",
+    "supertest": "6.1.3"
   },
   "files": [
     "HISTORY.md",


### PR DESCRIPTION
Update dependencies, specifically `multiparty@^4.2.2` for Node 14+ compatibility

https://github.com/pillarjs/multiparty/commit/6afaf7aa02121d7542cc1d9f7b42a563d215e521#diff-168726dbe96b3ce427e7fedce31bb0bcR53.